### PR TITLE
WIP: fix test DB with rails5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 sudo: false
 language: ruby
 cache: bundler
+addons:
+  apt:
+    sources:
+      - travis-ci/sqlite3
+    packages:
+      - sqlite3
 rvm:
   - 2.3.1
 gemfile:


### PR DESCRIPTION
Adding `rake db:migrate` in `before_script`  works but seems overkill: it should not necessary to run migrations in a test environment, especially since it works on 4.2.6. Bisecting might help here.